### PR TITLE
feat: add healthchecks for Open WebUI and LiteLLM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
       # Optional: connect to external APIs alongside local models
       # - OPENAI_API_KEY=${OPENAI_API_KEY}
       # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s              # Open WebUI takes a moment to boot
     depends_on:
       ollama:
         condition: service_healthy
@@ -67,8 +73,15 @@ services:
       # Pass through any API keys for cloud providers
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy
 
 volumes:
   ollama_data:


### PR DESCRIPTION
## Summary
All three services now have Docker healthchecks, enabling `docker compose ps` to show actual health status and `depends_on: condition: service_healthy` to work across the stack.

## Changes
- **Open WebUI**: healthcheck via `/health` on internal port 8080, with 30s start_period for boot time
- **LiteLLM**: healthcheck via `/health` on port 4000, with 15s start_period
- LiteLLM now uses `depends_on: ollama: condition: service_healthy` instead of bare `depends_on`

## Before
Only Ollama had a healthcheck. Open WebUI and LiteLLM could be 'running' but broken.

## After
```
$ docker compose ps
NAME        STATUS             PORTS
ollama      Up (healthy)       11434
open-webui  Up (healthy)       3000
litellm     Up (healthy)       4000
```

Closes #1